### PR TITLE
Remove the hard-coded path requirement

### DIFF
--- a/scenarios/scenario_1/infra/Pulumi.yaml
+++ b/scenarios/scenario_1/infra/Pulumi.yaml
@@ -1,8 +1,6 @@
 name: infra
 runtime:
   name: python
-  options:
-    virtualenv: ../../../venv
 description: A minimal AWS Python Pulumi program
 config:
   pulumi:tags:

--- a/scenarios/scenario_2/infra/Pulumi.yaml
+++ b/scenarios/scenario_2/infra/Pulumi.yaml
@@ -1,8 +1,6 @@
 name: ls
 runtime:
   name: python
-  options:
-    virtualenv: ../../../venv
 description: A minimal AWS Python Pulumi program
 config:
   pulumi:tags:

--- a/scenarios/scenario_3/infra/Pulumi.yaml
+++ b/scenarios/scenario_3/infra/Pulumi.yaml
@@ -1,8 +1,6 @@
 name: infra
 runtime:
   name: python
-  options:
-    virtualenv: ../../../venv
 description: A minimal AWS Python Pulumi program
 config:
   pulumi:tags:

--- a/scenarios/scenario_4/infra/Pulumi.yaml
+++ b/scenarios/scenario_4/infra/Pulumi.yaml
@@ -1,8 +1,7 @@
 name: infra
 runtime:
   name: python
-  options:
-    virtualenv: ../../../venv
+
 description: A minimal AWS Python Pulumi program
 config:
   pulumi:tags:


### PR DESCRIPTION
## Description

The path is previously hard-coded.  This can be removed and the tool will use the environment that is active at the time of execution

## Motivation and Context

The directions say to call is `venv`. But some may not follow that naming convention. And this would previously break the deployment. . 

## How Has This Been Tested?

Yes, I was able to launch with a virtual env named `env`

