### PR TITLE
Scenario 7 Update

### DIFF
--- a/scenarios/scenario_7/infra/__main__.py
+++ b/scenarios/scenario_7/infra/__main__.py
@@ -3,6 +3,8 @@ import vpc
 import utils
 import pulumi
 from pulumi_aws import eks
+# adding missing import to fix runtime error
+import pulumi_aws as aws
 
 # Create an EKS cluster with the default configuration.
 current = aws.get_region()

--- a/scenarios/scenario_7/infra/vpc.py
+++ b/scenarios/scenario_7/infra/vpc.py
@@ -1,4 +1,4 @@
-from pulumi_aws import ec2, get_availability_zones
+from pulumi_aws import ec2, get_availability_zones, get_region
 
 ## VPC
 
@@ -36,8 +36,21 @@ eks_route_table = ec2.RouteTable(
 )
 
 ## Subnets, one for each AZ in a region
+# Need region to avoid using forbidden AZs
+# https://docs.aws.amazon.com/eks/latest/userguide/network-reqs.html#network-requirements-subnets
+current = get_region()
+region = current.name
+exclude_zone_ids = []
 
-zones = get_availability_zones()
+
+if (region == "us-east-1"):
+    exclude_zone_ids.append("use1-az3")
+elif (region == "us-west-1"):
+    exclude_zone_ids.append("usw1-az2")
+elif (region == "ca-central-1"):
+    exclude_zone_ids.append("cac1-az3")
+
+zones = get_availability_zones(state="available", exclude_zone_ids=exclude_zone_ids)
 subnet_ids = []
 
 for zone in zones.names:


### PR DESCRIPTION
## Description

Scenario 7 was failing because there is a subnet in US-East-1 that you can't deploy EKS control plane nodes into. I linked the AWS page in the change to the VPC file and updated it to exclude the restricted subnets in the other two regions as well. Also, there was a forgotten import in main so the python crashed right away, I added that as well. 

## Motivation and Context
I changed this because I was using the tool and it failed to complete scenario 7

## How Has This Been Tested?

After making the changes I ensured that it deployed the EKS cluster successfully.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [x ] I have added tests to cover my changes if appropriate.
- [ x] All new and existing tests passed.
